### PR TITLE
Fix for %server_uptime%

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
@@ -123,7 +123,7 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 		case "unique_joins":
 			return String.valueOf(Bukkit.getOfflinePlayers().length);
 		case "uptime":
-			long seconds = TimeUnit.MILLISECONDS.toSeconds(ManagementFactory.getRuntimeMXBean().getStartTime());
+			long seconds = TimeUnit.MILLISECONDS.toSeconds(ManagementFactory.getRuntimeMXBean().getUptime());
 			return TimeUtil.getTime((int)seconds);
 		case "has_whitelist":
 			return Bukkit.getServer().hasWhitelist() ? PlaceholderAPIPlugin.booleanTrue() : PlaceholderAPIPlugin.booleanFalse();


### PR DESCRIPTION
Now:
It will get the time from when the server started (which won't change until another reboot.
Fix:
It will get the uptime from the server (I think you just made a small typo)