### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
         </dependency>
         <dependency>
          <groupId>me.clip</groupId>
-          <artifactId>PlaceholderAPI</artifactId>
-          <version>2.10.9</version>
+          <artifactId>placeholderapi</artifactId>
+          <version>2.10.10</version>
          <scope>provided</scope>
           <exclusions>
             <exclusion>


### PR DESCRIPTION
At some point PlaceholderAPI changed its maven artifact id to all lowercase,
This commit fixes the name in this extension's pom.xml so you no longer need to manually place the PlaceholderAPI jar in your maven cache manually.

While i was at it i also bumped the version up to latest.