### PR TITLE
Try and fix the paper build.

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
@@ -150,6 +150,7 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 			case "build":
 				return ServerUtils.BUILD;
 			case "version_build":
+			case "version_full":
 				return ServerUtils.VERSION + '-' + ServerUtils.BUILD;
 			// -----
 

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -2,16 +2,23 @@ package com.extendedclip.papi.expansion.server;
 
 import org.bukkit.Bukkit;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class ServerUtils {
 
     public static final String VERSION = Bukkit.getBukkitVersion().split("-")[0];
     public static final String BUILD;
+    
+    private static final Map<String, String> variants = new HashMap<>();
 
     static {
         boolean isPaper = false;
+        variants.put("Purpur", "net.pl3x.purpur.PurpurConfig");
+        variants.put("Airplane", "gg.airplane.AirplaneConfig");
+        variants.put("Tuinity", "com.tuinity.tuinity.config.TuinityConfig");
+        variants.put("Paper", "com.destroystokyo.paper.PaperConfig");
+        variants.put("Spigot", "org.spigotmc.SpigotConfig");
 
         try {
             Class.forName("com.destroystokyo.paper.PaperConfig");
@@ -21,7 +28,7 @@ public final class ServerUtils {
         String[] buildParts = Bukkit.getVersion().split("-");
 
         if (buildParts.length >= 3) {
-            BUILD = isPaper ? buildParts[2] : buildParts[0];
+            BUILD = isPaper ? buildParts[2].substring(0, buildParts[2].indexOf(" ")) : buildParts[0];
         } else {
             BUILD = "UNKNOWN";
         }
@@ -29,14 +36,7 @@ public final class ServerUtils {
 
     private ServerUtils() { }
 
-    @SuppressWarnings("SpellCheckingInspection")
     public static String getServerVariant() {
-        final Map<String, String> variants = new LinkedHashMap<>();
-        variants.put("Purpur", "net.pl3x.purpur.PurpurConfig");
-        variants.put("Airplane", "gg.airplane.AirplaneConfig");
-        variants.put("Tuinity", "com.tuinity.tuinity.config.TuinityConfig");
-        variants.put("Paper", "com.destroystokyo.paper.PaperConfig");
-        variants.put("Spigot", "org.spigotmc.SpigotConfig");
 
         for (Map.Entry<String, String> variant : variants.entrySet()) {
             try {


### PR DESCRIPTION
Adresses issues mentioned in #29 

I simply added a `substring(0, buildParts[2])` to the `buildParts[2]` section to exclude anything after the build number.

I also changed the `getServerVariant()` part a bit by moving the entire Map initialization and filling to static, so that it should only happen once.

Saying that I believe this needs some rework in order to improve it, especially in terms of maintainability for other forks which may or may not have different outputs for `Bukkit.getVersion()`

My idea would be a dedicated `getBuild()` method in the ServerUtil which would have a `switch` in it with the server variant and depending on it would return different parts of the output...