### PR TITLE
Improve ServerUtils and TPS resolving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 target/
 
 *.iml
+/dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,8 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
+            <id>paper-repo</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <repository>
             <id>placeholderapi</id>
@@ -23,9 +19,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.17-R0.1-SNAPSHOT</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
@@ -75,7 +75,6 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 
 	@Override
 	public void clear() {
-		serverUtils.clear();
 		dateFormats.clear();
 		serverUtils = null;
 		cache.invalidateAll();

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
@@ -274,24 +274,22 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 
 	public String getTps(String arg) {
 		if (arg == null || arg.isEmpty()) {
-			StringBuilder sb = new StringBuilder();
-			for (double t : serverUtils.getTps()) {
-				sb.append(getColoredTps(t))
-				  .append(ChatColor.GRAY)
-				  .append(", ");
+			StringJoiner joiner = new StringJoiner(ChatColor.GRAY + ", ");
+			for (double tps : serverUtils.getTps()) {
+				joiner.add(getColoredTps(tps));
 			}
-			return sb.toString();
+			return joiner.toString();
 		}
-		switch (arg) { 
+		switch (arg) {
 			case "1":
-			case "one":
-			return String.valueOf(fix(serverUtils.getTps()[0]));
+			case "one": 
+				return fix(serverUtils.getTps()[0]);
 			case "5":
 			case "five":
-				return String.valueOf(fix(serverUtils.getTps()[1]));
+				return fix(serverUtils.getTps()[1]);
 			case "15":
 			case "fifteen":
-				return String.valueOf(serverUtils.getTps()[2]);
+				return fix(serverUtils.getTps()[2]);
 			case "1_colored":
 			case "one_colored":
 				return getColoredTps(serverUtils.getTps()[0]);
@@ -388,13 +386,14 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 		return builder.toString();
 	}
 	
-	private double fix(double tps) {
-		return Math.min(Math.round(tps * 100.0) / 100.0, 20.0);
+	private String fix(double tps) {
+		double finalTps = Math.min(Math.round(tps), 20.0);
+		
+		return (tps > 20.0 ? "*" : "") + finalTps;
 	}
 	
 	private String color(double tps) {
-		return ChatColor.translateAlternateColorCodes('&', (tps > 18.0) ? high : (tps > 16.0) ? medium : low)
-				+ ((tps > 20.0) ? "*" : "");
+		return ChatColor.translateAlternateColorCodes('&', (tps > 18.0) ? high : (tps > 16.0) ? medium : low);
 	}
 	
 	private String getColoredTps(double tps) {
@@ -403,6 +402,12 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 	
 	private String getColoredTpsPercent(double tps){
 		return color(tps) + getPercent(tps);
+	}
+	
+	private String getPercent(double tps){
+		double finalPercent = Math.min(Math.round(100 / 20.0 * tps), 100.0);
+		
+		return (tps > 20.0 ? "*" : "") + finalPercent + "%";
 	}
 	
 	private Integer getChunks(){
@@ -431,9 +436,4 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 		
 		return allEntities;
 	}
-	
-	private String getPercent(double tps){
-		return Math.min(Math.round(100 / 20.0 * tps), 100.0) + "%";
-	}
-
 }

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerExpansion.java
@@ -46,11 +46,10 @@ import java.util.concurrent.TimeUnit;
 
 public class ServerExpansion extends PlaceholderExpansion implements Cacheable, Configurable {
 	
-	private final ServerUtils serverUtils;
+	private ServerUtils serverUtils = null;
 	
 	private final Map<String, SimpleDateFormat> dateFormats = new HashMap<>();
 	private final Runtime runtime = Runtime.getRuntime();
-	private final String variant;
 
 	// config stuff
 	private String serverName;
@@ -65,12 +64,6 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 
 	private final String VERSION = getClass().getPackage().getImplementationVersion();
 
-	public ServerExpansion() {
-		this.serverUtils = new ServerUtils();
-
-		this.variant = serverUtils.getServerVariant();
-	}
-
 	@Override
 	public boolean canRegister() {
 		serverName = this.getString("server_name", "A Minecraft Server");
@@ -84,7 +77,7 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 	public void clear() {
 		serverUtils.clear();
 		dateFormats.clear();
-		
+		serverUtils = null;
 		cache.invalidateAll();
 	}
 
@@ -114,8 +107,11 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 	}
 
 	@Override
-	public String onRequest(OfflinePlayer p, String identifier) {
+	public String onRequest(OfflinePlayer p, @NotNull String identifier) {
 		final int MB = 1048576;
+		if (serverUtils == null) {
+			serverUtils = new ServerUtils();
+		}
 
 		switch (identifier) {
 			// Players placeholders
@@ -152,7 +148,7 @@ public class ServerExpansion extends PlaceholderExpansion implements Cacheable, 
 			case "name":
 				return serverName == null ? "" : serverName;
 			case "variant":
-				return variant;
+				return serverUtils.getServerVariant();
 			// -----
 
 			// Other placeholders

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -24,7 +24,7 @@ public final class ServerUtils {
     private boolean hasTpsMethod = false;
     
     public ServerUtils() {
-        variants.put("Spigot", "org.spigotnc.SpigotConfig");
+        variants.put("Spigot", "org.spigotmc.SpigotConfig");
         variants.put("Paper", "com.destroystokyo.paper.PaperConfig");
         variants.put("Tuinity", "com.tuinity.tuinity.config.TuinityConfig");
         variants.put("Airplane", "gg.airplane.AirplaneConfig");
@@ -106,9 +106,9 @@ public final class ServerUtils {
     private void resolveTPSHandler() {
         try {
             // If this throws is the server not a fork...
-            Bukkit.getTPS();
+            Class.forName("org.bukkit.Bukkit").getMethod("getTPS");
             hasTpsMethod = true;
-        } catch (Exception ignored) {
+        } catch (ClassNotFoundException | NoSuchMethodException ignored) {
             final String mcVersion = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
             
             try {

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -1,51 +1,148 @@
 package com.extendedclip.papi.expansion.server;
 
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import org.bukkit.Bukkit;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class ServerUtils {
-
-    public static final String VERSION = Bukkit.getBukkitVersion().split("-")[0];
-    public static final String BUILD;
     
-    private static final Map<String, String> variants = new HashMap<>();
-
-    static {
-        boolean isPaper = false;
-        variants.put("Purpur", "net.pl3x.purpur.PurpurConfig");
-        variants.put("Airplane", "gg.airplane.AirplaneConfig");
-        variants.put("Tuinity", "com.tuinity.tuinity.config.TuinityConfig");
+    private String version = null;
+    private String build = null;
+    private String variant = null;
+    
+    private final Map<String, String> variants = new HashMap<>();
+    
+    private Object craftServer = null;
+    private Field tps = null;
+    
+    private boolean hasTpsMethod = false;
+    
+    public ServerUtils() {
+        variants.put("Spigot", "org.spigotnc.SpigotConfig");
         variants.put("Paper", "com.destroystokyo.paper.PaperConfig");
-        variants.put("Spigot", "org.spigotmc.SpigotConfig");
-
-        try {
-            Class.forName("com.destroystokyo.paper.PaperConfig");
-            isPaper = true;
-        } catch (ClassNotFoundException ignored) { }
-
-        String[] buildParts = Bukkit.getVersion().split("-");
-
-        if (buildParts.length >= 3) {
-            BUILD = isPaper ? buildParts[2].substring(0, buildParts[2].indexOf(" ")) : buildParts[0];
-        } else {
-            BUILD = "UNKNOWN";
-        }
+        variants.put("Tuinity", "com.tuinity.tuinity.config.TuinityConfig");
+        variants.put("Airplane", "gg.airplane.AirplaneConfig");
+        variants.put("Purpur", "net.pl3x.purpur.PurpurConfig");
+        
+        resolveTPSHandler();
     }
-
-    private ServerUtils() { }
-
-    public static String getServerVariant() {
-
-        for (Map.Entry<String, String> variant : variants.entrySet()) {
+    
+    public String getServerVariant() {
+        if (variant != null) {
+            return variant;
+        }
+        
+        for(Map.Entry<String, String> variant : variants.entrySet()) {
             try {
                 Class.forName(variant.getValue());
-                return variant.getKey();
-            } catch (ClassNotFoundException ignored) { }
+                
+                return (this.variant = variant.getKey());
+            } catch (ClassNotFoundException ignored) {} 
         }
-
-        return "Unknown";
+        
+        return (this.variant = "Unknown");
     }
-
+    
+    public String getVersion() {
+        if (version != null) {
+            return version;
+        }
+        
+        return (version = Bukkit.getBukkitVersion().split("-")[0]);
+    }
+    
+    public String getBuild() {
+        if (build != null) {
+            return build;
+        }
+        
+        String[] buildParts = Bukkit.getVersion().split("-");
+        switch (getServerVariant().toLowerCase(Locale.ROOT)) {
+            case "spigot":
+            // TODO: Find out what those variants return.
+            case "tuinity":
+            case "airplane":
+            case "purpur":
+                return (build = buildParts[0]);
+            
+            case "paper":
+                if (buildParts.length >= 3) {
+                    if (buildParts[2].contains(" ")) {
+                        return (build = buildParts[2].substring(0, buildParts[2].indexOf(" ")));
+                    } else {
+                        return (build = buildParts[2]);
+                    }
+                } else {
+                    return (build = "Unknown");
+                }
+            
+            default:
+                return (build = "Unknown");
+        }
+    }
+    
+    public void clear() {
+        craftServer = null;
+        tps = null;
+    }
+    
+    public double[] getTps() {
+        if (hasTpsMethod) {
+            return Bukkit.getTPS();
+        }
+        
+        if (craftServer == null || tps == null) {
+            return new double[]{0, 0, 0};
+        }
+        
+        try {
+            return (double[]) tps.get(craftServer);
+        } catch (IllegalAccessException ignored) {
+            return new double[]{0, 0, 0};
+        }
+    }
+    
+    private void resolveTPSHandler() {
+        try {
+            // If this throws is the server not a fork...
+            Bukkit.getTPS();
+            hasTpsMethod = true;
+        } catch (Exception ignored) {
+            final String mcVersion = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+            
+            try {
+                if (getMajorVersion() >= 17) {
+                    craftServer = Class.forName("net.minecraft.server.MinecraftServer")
+                        .getMethod("getServer").invoke(null);
+                } else {
+                    craftServer = Class.forName("net.minecraft.server." + mcVersion + ".MinecraftServer")
+                        .getMethod("getServer").invoke(null);
+                }
+                
+                tps = craftServer.getClass().getField("recentTps");
+            } catch (Exception ex) {
+                PlaceholderAPIPlugin.getInstance().getLogger().warning("Could not resolve TPS handling!");
+                ex.printStackTrace();
+            }
+        }
+    }
+    
+    private int getMajorVersion() {
+        final Matcher matcher = Pattern.compile("\\(MC: (\\d)\\.(\\d+)\\.?(\\d+?)?\\)").matcher(Bukkit.getVersion());
+        if (matcher.find()) {
+            try{
+                return Integer.parseInt(matcher.toMatchResult().group(2), 10);
+            } catch (NumberFormatException ignored) {
+                return -1;
+            }
+        } else {
+            return -1;
+        }
+    }
 }

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -93,7 +93,6 @@ public final class ServerUtils {
     }
     
     public double[] getTps() {
-        System.out.println(hasTpsMethod);
         if (hasTpsMethod) {
             return Bukkit.getTPS();
         }

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -93,6 +93,7 @@ public final class ServerUtils {
     }
     
     public double[] getTps() {
+        System.out.println(hasTpsMethod);
         if (hasTpsMethod) {
             return Bukkit.getTPS();
         }

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -106,9 +106,9 @@ public final class ServerUtils {
     private void resolveTPSHandler() {
         try {
             // If this throws is the server not a fork...
-            Class.forName("org.bukkit.Bukkit").getMethod("getTPS");
+            Bukkit.class.getMethod("getTPS");
             hasTpsMethod = true;
-        } catch (ClassNotFoundException | NoSuchMethodException ignored) {
+        } catch (NoSuchMethodException ignored) {
             final String mcVersion = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
             
             try {

--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -87,11 +87,6 @@ public final class ServerUtils {
         }
     }
     
-    public void clear() {
-        craftServer = null;
-        tps = null;
-    }
-    
     public double[] getTps() {
         if (hasTpsMethod) {
             return Bukkit.getTPS();


### PR DESCRIPTION
Improves the `ServerUtils` class in various ways:

- Made methods non-static and instead create a ServerUtils instance in onRequest.
- Moved TPS handling to ServerUtils class
- Made TPS handling use Paper's `Bukkit.getTPS()` method when available, otherwise fall back to internal handling.
- Fixed random inconsistencies in TPS values (i.e. `tps_15` returning non-rounded number)
- Other misc changes I can't remember.

I've made some basic tests on a PaperMC server (MC 1.17.2, build 273) which all were successful and without any exceptions or errors.