### PR TITLE
Add variant check for paper 1.19+

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
+++ b/src/main/java/com/extendedclip/papi/expansion/server/ServerUtils.java
@@ -24,11 +24,12 @@ public final class ServerUtils {
     private boolean hasTpsMethod = false;
     
     public ServerUtils() {
-        variants.put("Spigot", "org.spigotmc.SpigotConfig");
-        variants.put("Paper", "com.destroystokyo.paper.PaperConfig");
-        variants.put("Tuinity", "com.tuinity.tuinity.config.TuinityConfig");
-        variants.put("Airplane", "gg.airplane.AirplaneConfig");
-        variants.put("Purpur", "net.pl3x.purpur.PurpurConfig");
+        variants.put("org.spigotmc.SpigotConfig", "Spigot");
+        variants.put("io.papermc.paper.configuration.ConfigurationLoaders", "Paper"); // New config location for Paper 1.19+
+        variants.put("com.destroystokyo.paper.PaperConfig", "Paper"); // Still supported by Paper, but deprecated.
+        variants.put("com.tuinity.tuinity.config.TuinityConfig", "Tuinity");
+        variants.put("gg.airplane.AirplaneConfig", "Airplane");
+        variants.put("net.pl3x.purpur.PurpurConfig", "Purpur");
         
         resolveTPSHandler();
     }
@@ -40,9 +41,9 @@ public final class ServerUtils {
         
         for(Map.Entry<String, String> variant : variants.entrySet()) {
             try {
-                Class.forName(variant.getValue());
+                Class.forName(variant.getKey());
                 
-                return (this.variant = variant.getKey());
+                return (this.variant = variant.getValue());
             } catch (ClassNotFoundException ignored) {} 
         }
         


### PR DESCRIPTION
Paper split up their configuration in 1.19, which is also reflected in their code.
The new path for the configs is found under `io.papermc.paper.configuration.ConfigurationLoaders`

While the old `com.destroystokyo.paper.PaperConfig` is still present, is it deprecated and could be removed in future versions, therefore it's best to check for both classes to be sure.
The result would be the same either way, so nothing breaking here.