### PR TITLE
Use ServerBuildInfo when available (Fixes #59)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.3")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/at/helpch/placeholderapi/expansion/server/util/ServerUtil.java
+++ b/src/main/java/at/helpch/placeholderapi/expansion/server/util/ServerUtil.java
@@ -1,10 +1,12 @@
 package at.helpch.placeholderapi.expansion.server.util;
 
+import io.papermc.paper.ServerBuildInfo;
 import org.bukkit.Bukkit;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.TreeMap;
 
 public final class ServerUtil {
@@ -32,6 +34,9 @@ public final class ServerUtil {
     }
 
     private static String findVariant() {
+        if (hasServerBuildInfo())
+            return getVariant0();
+
         for (final Map.Entry<String, String> entry : variants.entrySet()) {
             try {
                     Class.forName(entry.getKey());
@@ -97,6 +102,9 @@ public final class ServerUtil {
     }
 
     private static String findBuild() {
+        if (hasServerBuildInfo())
+            return getBuild0();
+
         String[] buildParts = Bukkit.getVersion().split("-");
 
         switch (getVariant().toLowerCase()) {
@@ -153,4 +161,25 @@ public final class ServerUtil {
         }
     }
 
+    // Available since recent 1.20.6 versions of Paper. Allows easier retrieval of certain info.
+    private static boolean hasServerBuildInfo() {
+        try {
+            Class.forName("io.papermc.paper.ServerBuildInfo");
+            return true;
+        } catch(ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    private static String getVariant0() {
+        return ServerBuildInfo.buildInfo().brandName();
+    }
+
+    private static String getBuild0() {
+        OptionalInt buildNumber = ServerBuildInfo.buildInfo().buildNumber();
+        if (buildNumber.isEmpty())
+            return "Unknown";
+
+        return String.valueOf(buildNumber.getAsInt());
+    }
 }


### PR DESCRIPTION
*Should* fix #59 by using the ServerBuildInfo class of paper when available to fix the `version_full` placeholder output.

(Not sure why someone would use that, but hey... It's fixed).

This also updates Gradle to 8.7 and Paper API to 1.20.6. Updated gradle because there were issues with 8.0 and Java 17/21.