### PR TITLE
Switch to ZonedDateTime from LocalDateTime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
-    compileOnly("me.clip:placeholderapi:2.11.3")
+    compileOnly("me.clip:placeholderapi:2.11.6")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ version = "2.7.3"
 
 repositories {
     mavenCentral()
-    maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
-    compileOnly("me.clip:placeholderapi:2.11.6")
+    compileOnly("me.clip:placeholderapi:2.11.7")
 }
 
 tasks {

--- a/src/main/java/at/helpch/placeholderapi/expansion/server/util/TimeFormatter.java
+++ b/src/main/java/at/helpch/placeholderapi/expansion/server/util/TimeFormatter.java
@@ -145,9 +145,11 @@ public final class TimeFormatter {
             return "invalid date format";
         }
 
+        DateTimeFormatter zonedFormatter = formatter.withZone(timeZone);
+
         try {
             ZonedDateTime now = ZonedDateTime.now(timeZone);
-            ZonedDateTime otherDate = ZonedDateTime.parse(otherDateString, formatter);
+            ZonedDateTime otherDate = ZonedDateTime.parse(otherDateString, zonedFormatter);
 
             if (otherDate.isEqual(now)) {
                 return "0";
@@ -162,7 +164,7 @@ public final class TimeFormatter {
             return formatTime ? this.formatTimeInSeconds(time) : String.valueOf(time);
         } catch (DateTimeParseException e) {
             final String type = isCountdown ? "countdown" : "count-up";
-            Logging.error(e, "Could not calculate {0} (format: \"{1}\", other date: \"{2}\")", type, formatter.toString(), otherDateString);
+            Logging.error(e, "Could not calculate {0} (format: \"{1}\", other date: \"{2}\")", type, zonedFormatter.toString(), otherDateString);
             return "invalid date";
         }
     }

--- a/src/main/java/at/helpch/placeholderapi/expansion/server/util/TimeFormatter.java
+++ b/src/main/java/at/helpch/placeholderapi/expansion/server/util/TimeFormatter.java
@@ -7,8 +7,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.DateTimeException;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -64,7 +64,7 @@ public final class TimeFormatter {
      * Format the current time with the given format
      *
      * @param format format
-     * @return {@code null} if the format is empty or invalid, otherwise {@link LocalDateTime#now(ZoneId)} formatted
+     * @return {@code null} if the format is empty or invalid, otherwise {@link ZonedDateTime#now(ZoneId)} formatted
      */
     public @Nullable String formatTime(@NotNull final String format) {
         if (format.trim().isEmpty()) {
@@ -72,7 +72,7 @@ public final class TimeFormatter {
         }
 
         return Optional.ofNullable(parseFormat(format))
-            .map(formatter -> LocalDateTime.now(timeZone).format(formatter))
+            .map(formatter -> ZonedDateTime.now(timeZone).format(formatter))
             .orElse(null);
     }
 
@@ -110,7 +110,7 @@ public final class TimeFormatter {
     }
 
     /**
-     * Calculate the time between {@link LocalDateTime#now(ZoneId)} and another date and return a formatted value
+     * Calculate the time between {@link ZonedDateTime#now(ZoneId)} and another date and return a formatted value
      * using {@link #formatTimeInSeconds(long)} if {@code formatTime} is {@code true}.
      *
      * @param player      player
@@ -146,8 +146,8 @@ public final class TimeFormatter {
         }
 
         try {
-            LocalDateTime now = LocalDateTime.now(timeZone);
-            LocalDateTime otherDate = LocalDateTime.parse(otherDateString, formatter);
+            ZonedDateTime now = ZonedDateTime.now(timeZone);
+            ZonedDateTime otherDate = ZonedDateTime.parse(otherDateString, formatter);
 
             if (otherDate.isEqual(now)) {
                 return "0";


### PR DESCRIPTION
Since https://github.com/PlaceholderAPI/Server-Expansion/commit/d2962bc7fe2bc0571116c8c437e06dd1f3a85061 and the release of `2.7.3`, time zones and time zone placeholders can no longer be used for parsing and formatting due to the switch from `Date` to `LocalDateTime`.
 
![image](https://github.com/user-attachments/assets/48435503-81a5-4bf4-b19a-65613710c546)

This PR switches all usage of `LocalDateTime` to `ZonedDateTime` to once again restore this functionality. 
